### PR TITLE
Add nested sort attributes support

### DIFF
--- a/lib/jsonapi/query_builder.rb
+++ b/lib/jsonapi/query_builder.rb
@@ -2,13 +2,12 @@
 
 require "active_support/concern"
 require "active_support/core_ext/array/conversions"
-require "active_support/core_ext/array/extract_options"
 require "active_support/core_ext/hash/keys"
 require "active_support/core_ext/string/inflections"
-require "arel"
 require "pagy"
 require "pagy/extras/items"
 
 require "jsonapi/query_builder/version"
 require "jsonapi/query_builder/base_query"
 require "jsonapi/query_builder/base_filter"
+require "jsonapi/query_builder/base_sort"

--- a/lib/jsonapi/query_builder.rb
+++ b/lib/jsonapi/query_builder.rb
@@ -2,8 +2,10 @@
 
 require "active_support/concern"
 require "active_support/core_ext/array/conversions"
+require "active_support/core_ext/array/extract_options"
 require "active_support/core_ext/hash/keys"
 require "active_support/core_ext/string/inflections"
+require "arel"
 require "pagy"
 require "pagy/extras/items"
 

--- a/lib/jsonapi/query_builder/base_query.rb
+++ b/lib/jsonapi/query_builder/base_query.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "jsonapi/query_builder/mixins/filtering"
+require "jsonapi/query_builder/mixins/filter"
 require "jsonapi/query_builder/mixins/include"
 require "jsonapi/query_builder/mixins/paginate"
 require "jsonapi/query_builder/mixins/sort"
@@ -8,7 +8,7 @@ require "jsonapi/query_builder/mixins/sort"
 module Jsonapi
   module QueryBuilder
     class BaseQuery
-      include Mixins::Filtering
+      include Mixins::Filter
       include Mixins::Include
       include Mixins::Paginate
       include Mixins::Sort

--- a/lib/jsonapi/query_builder/base_query.rb
+++ b/lib/jsonapi/query_builder/base_query.rb
@@ -13,7 +13,7 @@ module Jsonapi
       include Mixins::Paginate
       include Mixins::Sort
 
-      attr_reader :collection, :params
+      attr_accessor :collection, :params
 
       def initialize(collection, params)
         @collection = collection
@@ -22,8 +22,8 @@ module Jsonapi
 
       def results
         collection
-          .yield_self(&method(:sort))
           .yield_self(&method(:add_includes))
+          .yield_self(&method(:sort))
           .yield_self(&method(:filter))
           .yield_self(&method(:paginate))
       end

--- a/lib/jsonapi/query_builder/base_sort.rb
+++ b/lib/jsonapi/query_builder/base_sort.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Jsonapi
+  module QueryBuilder
+    class BaseSort
+      attr_reader :collection, :direction
+
+      def initialize(collection, direction)
+        @collection = collection
+        @direction = direction
+      end
+
+      def results
+        raise NotImplementedError, "#{self.class} should implement #results"
+      end
+    end
+  end
+end

--- a/lib/jsonapi/query_builder/mixins/filter.rb
+++ b/lib/jsonapi/query_builder/mixins/filter.rb
@@ -3,7 +3,7 @@
 module Jsonapi
   module QueryBuilder
     module Mixins
-      module Filtering
+      module Filter
         extend ActiveSupport::Concern
 
         class_methods do

--- a/lib/jsonapi/query_builder/mixins/sort.rb
+++ b/lib/jsonapi/query_builder/mixins/sort.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "jsonapi/query_builder/mixins/sort/param"
+
 module Jsonapi
   module QueryBuilder
     module Mixins
@@ -15,30 +17,31 @@ module Jsonapi
             @_unique_sort_attributes || [id: :asc]
           end
 
-          def _sort_attributes
-            @_sort_attributes || []
+          def supported_sorts
+            @supported_sorts || {}
           end
 
           def unique_sort_attributes(*attributes)
             @_unique_sort_attributes = attributes
           end
+
           alias_method :unique_sort_attribute, :unique_sort_attributes
 
           def default_sort(options)
             @_default_sort = options
           end
 
-          def sorts_by(*attributes, **nested_attributes)
-            nested_sort_attributes = _sort_attributes.extract_options!
-            @_sort_attributes = _sort_attributes + attributes + [nested_sort_attributes.deep_merge(nested_attributes)]
+          def sorts_by(attribute, sort = nil)
+            sort ||= ->(collection, direction) { collection.order(attribute => direction) }
+            @supported_sorts = {**supported_sorts, attribute => sort}
           end
         end
 
         def sort(collection, sort_params = send(:sort_params))
+          sort_params = Param.deserialize_params(sort_params)
           ensure_permitted_sort_params!(sort_params) if sort_params
 
           collection
-            .yield_self { |c| add_joins_for_nested_attributes(c, sort_params) }
             .yield_self { |c| add_order_attributes(c, sort_params) }
             .yield_self(&method(:add_unique_order_attributes))
         end
@@ -50,16 +53,7 @@ module Jsonapi
         end
 
         def ensure_permitted_sort_params!(sort_params)
-          unpermitted_parameters =
-            sort_params
-              .split(",")
-              .map(&method(:deserialize_param))
-              .reject { |_, model, attribute|
-                (model.nil? ? self.class._sort_attributes : self.class._sort_attributes[-1].fetch(model.to_sym, []))
-                  .include?(attribute.to_sym)
-              }
-              .map { |_, model, param| serialize_param(nil, model, param) }
-
+          unpermitted_parameters = sort_params.map(&:attribute).map(&:to_sym) - self.class.supported_sorts.keys
           return if unpermitted_parameters.size.zero?
 
           raise UnpermittedSortParameters, [
@@ -69,48 +63,23 @@ module Jsonapi
           ].join(" ")
         end
 
-        def add_joins_for_nested_attributes(collection, sort_params)
-          relationships =
-            sort_params
-              &.split(",")
-              &.map { |param| deserialize_param(param)[1] }
-              &.compact
-              &.uniq
-              &.map(&:to_sym)
-
-          relationships.present? ? collection.left_joins(*relationships) : collection
-        end
-
         def add_order_attributes(collection, sort_params)
-          collection.reorder(sort_params.nil? ? self.class._default_sort : formatted_sort_params(sort_params))
+          return collection if self.class._default_sort.nil? && sort_params.blank?
+          return collection.order(self.class._default_sort) if sort_params.blank?
+
+          sort_params.reduce(collection) do |sorted_collection, sort_param|
+            sort = self.class.supported_sorts.fetch(sort_param.attribute.to_sym)
+
+            if sort.respond_to?(:call)
+              sort.call(sorted_collection, sort_param.direction)
+            else
+              sort.new(sorted_collection, sort_param.direction).results
+            end
+          end
         end
 
         def add_unique_order_attributes(collection)
           collection.order(*self.class._unique_sort_attributes)
-        end
-
-        def formatted_sort_params(sort_params)
-          sort_params.split(",").map(&method(:format_param))
-        end
-
-        def deserialize_param(param)
-          _, desc, model, attribute = param.strip.match(/^(?<desc>-)?(?>(?<model>[^.]*)\.)*(?<attribute>.*)$/).to_a
-
-          [desc, model, attribute]
-        end
-
-        def serialize_param(desc, model, attribute)
-          model &&= "#{model}."
-
-          [desc, model, attribute].compact.join
-        end
-
-        def format_param(attribute_parameter)
-          desc, model, attribute = deserialize_param attribute_parameter
-
-          direction = desc.present? ? :desc : :asc
-
-          (model.present? ? model.classify.constantize.arel_table[attribute] : Arel.sql(attribute)).send(direction)
         end
       end
     end

--- a/lib/jsonapi/query_builder/mixins/sort.rb
+++ b/lib/jsonapi/query_builder/mixins/sort.rb
@@ -28,15 +28,19 @@ module Jsonapi
             @_default_sort = options
           end
 
-          def sorts_by(*attributes)
-            @_sort_attributes = _sort_attributes + attributes
+          def sorts_by(*attributes, **nested_attributes)
+            nested_sort_attributes = _sort_attributes.extract_options!
+            @_sort_attributes = _sort_attributes + attributes + [nested_sort_attributes.deep_merge(nested_attributes)]
           end
         end
 
         def sort(collection, sort_params = send(:sort_params))
+          ensure_permitted_sort_params!(sort_params) if sort_params
+
           collection
-            .reorder(sort_params.nil? ? self.class._default_sort : formatted_sort_params(sort_params))
-            .tap(&method(:add_unique_order_attributes))
+            .yield_self { |c| add_joins_for_nested_attributes(c, sort_params) }
+            .yield_self { |c| add_order_attributes(c, sort_params) }
+            .yield_self(&method(:add_unique_order_attributes))
         end
 
         private
@@ -45,27 +49,68 @@ module Jsonapi
           params[:sort]
         end
 
-        def add_unique_order_attributes(collection)
-          collection.order(*self.class._unique_sort_attributes)
-        end
-
-        def formatted_sort_params(sort_params)
-          sort_params
-            .split(",")
-            .map(&:strip)
-            .to_h { |attribute| attribute.start_with?("-") ? [attribute[1..-1], :desc] : [attribute, :asc] }
-            .symbolize_keys
-            .tap(&method(:ensure_permitted_sort_params!))
-        end
-
         def ensure_permitted_sort_params!(sort_params)
-          return if (unpermitted_parameters = sort_params.keys - self.class._sort_attributes.map(&:to_sym)).size.zero?
+          unpermitted_parameters =
+            sort_params
+              .split(",")
+              .map(&method(:deserialize_param))
+              .reject { |_, model, attribute|
+                (model.nil? ? self.class._sort_attributes : self.class._sort_attributes[-1].fetch(model.to_sym, []))
+                  .include?(attribute.to_sym)
+              }
+              .map { |_, model, param| serialize_param(nil, model, param) }
+
+          return if unpermitted_parameters.size.zero?
 
           raise UnpermittedSortParameters, [
             unpermitted_parameters.to_sentence,
             unpermitted_parameters.count == 1 ? "is not a" : "are not",
             "permitted sort attribute".pluralize(unpermitted_parameters.count)
           ].join(" ")
+        end
+
+        def add_joins_for_nested_attributes(collection, sort_params)
+          relationships =
+            sort_params
+              &.split(",")
+              &.map { |param| deserialize_param(param)[1] }
+              &.compact
+              &.uniq
+              &.map(&:to_sym)
+
+          relationships.present? ? collection.left_joins(*relationships) : collection
+        end
+
+        def add_order_attributes(collection, sort_params)
+          collection.reorder(sort_params.nil? ? self.class._default_sort : formatted_sort_params(sort_params))
+        end
+
+        def add_unique_order_attributes(collection)
+          collection.order(*self.class._unique_sort_attributes)
+        end
+
+        def formatted_sort_params(sort_params)
+          sort_params.split(",").map(&method(:format_param))
+        end
+
+        def deserialize_param(param)
+          _, desc, model, attribute = param.strip.match(/^(?<desc>-)?(?>(?<model>[^.]*)\.)*(?<attribute>.*)$/).to_a
+
+          [desc, model, attribute]
+        end
+
+        def serialize_param(desc, model, attribute)
+          model &&= "#{model}."
+
+          [desc, model, attribute].compact.join
+        end
+
+        def format_param(attribute_parameter)
+          desc, model, attribute = deserialize_param attribute_parameter
+
+          direction = desc.present? ? :desc : :asc
+
+          (model.present? ? model.classify.constantize.arel_table[attribute] : Arel.sql(attribute)).send(direction)
         end
       end
     end

--- a/lib/jsonapi/query_builder/mixins/sort/param.rb
+++ b/lib/jsonapi/query_builder/mixins/sort/param.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Jsonapi
+  module QueryBuilder
+    module Mixins
+      module Sort
+        class Param
+          attr_reader :descending, :attribute
+
+          def initialize(param)
+            @descending, @attribute = deserialize(param)
+          end
+
+          class << self
+            def deserialize_params(sort_params)
+              (sort_params || "").split(",").map(&method(:new))
+            end
+          end
+
+          def deserialize(param)
+            _, descending, attribute = param.strip.match(/^(?<descending>-)?(?<attribute>.*)$/).to_a
+
+            [descending, attribute]
+          end
+
+          def serialize
+            [descending, attribute].compact.join
+          end
+
+          def direction
+            descending.present? ? :desc : :asc
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/jsonapi/query_builder/base_sort_spec.rb
+++ b/spec/jsonapi/query_builder/base_sort_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe Jsonapi::QueryBuilder::BaseSort do
+  before do
+    stub_const "FakeSort", sort_class
+  end
+
+  context "with required interface methods" do
+    let(:sort_class) { Class.new(described_class) }
+
+    it "raises an error for results method" do
+      expect { FakeSort.new(instance_double("collection"), :desc).results }.to raise_error(
+        NotImplementedError, "FakeSort should implement #results"
+      )
+    end
+  end
+end

--- a/spec/jsonapi/query_builder/mixins/filter_spec.rb
+++ b/spec/jsonapi/query_builder/mixins/filter_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-RSpec.describe Jsonapi::QueryBuilder::Mixins::Filtering do
+RSpec.describe Jsonapi::QueryBuilder::Mixins::Filter do
   describe "DSL" do
     subject(:filterable_query_class) do
       Class.new {
-        include Jsonapi::QueryBuilder::Mixins::Filtering
+        include Jsonapi::QueryBuilder::Mixins::Filter
       }
     end
 
@@ -54,7 +54,7 @@ RSpec.describe Jsonapi::QueryBuilder::Mixins::Filtering do
 
     let(:filterable_query_class) do
       Class.new {
-        include Jsonapi::QueryBuilder::Mixins::Filtering
+        include Jsonapi::QueryBuilder::Mixins::Filter
 
         attr_reader :params
 
@@ -79,9 +79,7 @@ RSpec.describe Jsonapi::QueryBuilder::Mixins::Filtering do
       allow(collection).to receive(:where).and_return(collection)
     end
 
-    it "returns the filtered collection" do
-      expect(filter).to eql collection
-    end
+    it { is_expected.to eql collection }
 
     it "filters by present simple filter" do
       filter
@@ -190,7 +188,7 @@ RSpec.describe Jsonapi::QueryBuilder::Mixins::Filtering do
     context "when no filters are set" do
       let(:filterable_query_class) do
         Class.new {
-          include Jsonapi::QueryBuilder::Mixins::Filtering
+          include Jsonapi::QueryBuilder::Mixins::Filter
 
           attr_reader :params
 

--- a/spec/jsonapi/query_builder/mixins/sort/param_spec.rb
+++ b/spec/jsonapi/query_builder/mixins/sort/param_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+RSpec.describe Jsonapi::QueryBuilder::Mixins::Sort::Param do
+  subject(:sort_param) { described_class.new(parameter) }
+
+  let(:parameter) { "-attribute_name" }
+
+  it "deserializes the parameter into desc and attribute" do
+    expect(sort_param).to have_attributes descending: "-", attribute: "attribute_name"
+  end
+
+  it "descending equals null if parameter has ascending direction" do
+    expect(described_class.new("attribute_name").descending).to be_nil
+  end
+
+  it "strips param" do
+    expect(described_class.new("   -attribute_name   ")).to have_attributes descending: "-", attribute: "attribute_name"
+  end
+
+  describe ".deserialize_params" do
+    subject { described_class.deserialize_params("first_name,-last_name") }
+
+    it { is_expected.to be_an Array }
+    it { is_expected.to all be_an_instance_of described_class }
+    it { is_expected.to include have_attributes descending: nil, attribute: "first_name" }
+    it { is_expected.to include have_attributes descending: "-", attribute: "last_name" }
+  end
+
+  describe "#serialize" do
+    subject { sort_param.serialize }
+
+    it { is_expected.to be_a String }
+    it { is_expected.to eql "-attribute_name" }
+  end
+
+  describe "#direction" do
+    subject { sort_param.direction }
+
+    context "when parameter starts with -" do
+      let(:parameter) { "-attribute_name" }
+
+      it { is_expected.to be :desc }
+    end
+
+    context "when parameter does not start with -" do
+      let(:parameter) { "attribute_name" }
+
+      it { is_expected.to be :asc }
+    end
+  end
+end

--- a/spec/jsonapi/query_builder/mixins/sort_spec.rb
+++ b/spec/jsonapi/query_builder/mixins/sort_spec.rb
@@ -1,83 +1,86 @@
 # frozen_string_literal: true
 
 RSpec.describe Jsonapi::QueryBuilder::Mixins::Sort do
-  subject(:test_query_class) {
-    Class.new {
-      include Jsonapi::QueryBuilder::Mixins::Sort
-    }
-  }
-
-  before do
-    stub_const "TestQuery", test_query_class
-  end
-
   describe "DSL" do
+    subject(:sortable_query_class) {
+      Class.new {
+        include Jsonapi::QueryBuilder::Mixins::Sort
+      }
+    }
+
+    before do
+      stub_const "SortableQuery", sortable_query_class
+    end
+
     describe ".unique_sort_attribute" do
       it "defaults to id ascending if not set" do
-        expect(TestQuery._unique_sort_attributes).to eql [id: :asc]
+        expect(SortableQuery._unique_sort_attributes).to eql [id: :asc]
       end
 
       it "sets the unique sort attribute" do
-        TestQuery.unique_sort_attribute :email
+        SortableQuery.unique_sort_attribute :email
 
-        expect(TestQuery._unique_sort_attributes).to eql [:email]
+        expect(SortableQuery._unique_sort_attributes).to eql [:email]
       end
 
       it "sets compound unique sort attributes" do
-        TestQuery.unique_sort_attributes :created_at, id: :asc
+        SortableQuery.unique_sort_attributes :created_at, id: :asc
 
-        expect(TestQuery._unique_sort_attributes).to eql [:created_at, id: :asc]
+        expect(SortableQuery._unique_sort_attributes).to eql [:created_at, id: :asc]
       end
     end
 
     describe ".default_sort" do
       it "sets the default sort setting" do
-        TestQuery.default_sort created_at: :desc
+        SortableQuery.default_sort created_at: :desc
 
-        expect(TestQuery._default_sort).to eql created_at: :desc
+        expect(SortableQuery._default_sort).to eql created_at: :desc
       end
     end
 
     describe ".sorts_by" do
       it "registers a supported sort attribute" do
-        TestQuery.sorts_by :first_name
+        SortableQuery.sorts_by :first_name
 
-        expect(TestQuery._sort_attributes).to include(:first_name)
+        expect(SortableQuery.supported_sorts).to include(:first_name)
       end
 
-      it "registers multiple sort attributes at the same time" do
-        TestQuery.sorts_by :first_name, :last_name
+      it "adds a default sort proc" do
+        SortableQuery.sorts_by :first_name
 
-        expect(TestQuery._sort_attributes).to include(:first_name, :last_name)
+        expect(SortableQuery.supported_sorts).to include(first_name: an_instance_of(Proc))
       end
 
-      it "does not clear existing registered sort attributes" do
-        TestQuery.sorts_by :first_name
-        TestQuery.sorts_by :last_name
+      it "adds a custom sort" do
+        sort = ->(collection, direction) { collection.order(first_name: direction) }
 
-        expect(TestQuery._sort_attributes).to include(:first_name, :last_name)
+        SortableQuery.sorts_by :first_name, sort
+
+        expect(SortableQuery.supported_sorts).to include(first_name: sort)
       end
 
-      it "registers a nested sort attribute as last item" do
-        TestQuery.sorts_by user: %i[first_name last_name]
-        TestQuery.sorts_by :email
+      it "can add multiple different sorts" do
+        SortableQuery.sorts_by :first_name
+        SortableQuery.sorts_by :last_name
 
-        expect(TestQuery._sort_attributes[-1]).to eql(user: %i[first_name last_name])
+        expect(SortableQuery.supported_sorts).to include(:first_name, :last_name)
       end
     end
   end
 
   describe "#sort" do
-    subject(:sort) { TestQuery.new(collection, sort_params).sort(collection) }
+    subject(:sort) { SortableQuery.new(collection, params).sort(collection) }
 
-    let(:test_query_class) {
+    let(:sortable_query_class) {
       Class.new {
         include Jsonapi::QueryBuilder::Mixins::Sort
 
         attr_reader :params
 
         unique_sort_attribute id: :asc
-        sorts_by :first_name, :last_name
+        sorts_by :last_name
+        sorts_by :first_name, ->(collection, direction) { collection.order(name: direction) }
+        sorts_by :'address.street', StreetSort
 
         def initialize(collection, params)
           @collection = collection
@@ -85,149 +88,101 @@ RSpec.describe Jsonapi::QueryBuilder::Mixins::Sort do
         end
       }
     }
-    let(:collection) { instance_double "collection", reorder: reordered_collection }
-    let(:reordered_collection) { instance_double "reordered_collection", order: ordered_collection }
-    let(:ordered_collection) { instance_double "ordered_collection" }
-
-    let(:sort_params) { {} }
+    let(:street_sort_class) { class_double "StreetSort", new: street_sort_instance }
+    let(:street_sort_instance) { instance_double "street_sort", results: collection }
+    let(:collection) { instance_double "collection" }
+    let(:params) { {sort: "first_name,-last_name,address.street"} }
 
     before do
-      allow(Arel).to receive(:sql).with("first_name")
-        .and_return(instance_double(Arel::Nodes::SqlLiteral, asc: "first_name_asc", desc: "first_name_desc"))
-      allow(Arel).to receive(:sql).with("last_name")
-        .and_return(instance_double(Arel::Nodes::SqlLiteral, asc: "last_name_asc", desc: "last_name_desc"))
+      stub_const "StreetSort", street_sort_class
+      stub_const "SortableQuery", sortable_query_class
+
+      allow(collection).to receive(:order).and_return(collection)
     end
 
-    it "returns the sorted collection" do
-      expect(sort).to eql(ordered_collection)
+    it { is_expected.to eql collection }
+
+    it "sorts by the present simple sort" do
+      sort
+
+      expect(collection).to have_received(:order).with(last_name: :desc)
+    end
+
+    it "sorts by the present lambda sort" do
+      sort
+
+      expect(collection).to have_received(:order).with(name: :asc)
+    end
+
+    it "sorts by present class sort", :aggregate_failures do
+      sort
+
+      expect(StreetSort).to have_received(:new).with(collection, :asc)
+      expect(street_sort_instance).to have_received(:results)
+    end
+
+    it "adds the unique sort attribute" do
+      sort
+
+      expect(collection).to have_received(:order).with(id: :asc)
     end
 
     context "when sort params are empty and a default sort is not set" do
-      it "clears the order" do
+      let(:params) { {} }
+
+      it "fallbacks to the unique sort attributes", :aggregate_failures do
         sort
 
-        expect(collection).to have_received(:reorder).with(nil)
-      end
-
-      it "fallbacks to the unique sort attributes" do
-        sort
-
-        expect(reordered_collection).to have_received(:order).with(id: :asc)
+        expect(collection).to have_received(:order).once
+        expect(collection).to have_received(:order).with(id: :asc)
       end
     end
 
     context "when sort params are empty and a default sort is set" do
+      let(:params) { {} }
+
       before do
-        TestQuery.default_sort :first_name
+        SortableQuery.default_sort :first_name
       end
 
       it "adds a default sort" do
         sort
 
-        expect(collection).to have_received(:reorder).with(:first_name)
+        expect(collection).to have_received(:order).with(:first_name)
       end
 
       it "ensures a unique sort attribute" do
         sort
 
-        expect(reordered_collection).to have_received(:order).with(id: :asc)
-      end
-    end
-
-    context "when sort params are present and permitted" do
-      let(:sort_params) { {sort: "first_name,-last_name"} }
-
-      it "sets asc order direction for params not starting with -" do
-        sort
-
-        expect(collection).to have_received(:reorder).with(include("first_name_asc"))
-      end
-
-      it "sets desc order direction for params starting with -" do
-        sort
-
-        expect(collection).to have_received(:reorder).with(include("last_name_desc"))
-      end
-
-      it "strips params" do
-        TestQuery.new(collection, sort: " -first_name ,  last_name ").sort(collection)
-
-        expect(collection).to have_received(:reorder).with(%w[first_name_desc last_name_asc])
-      end
-    end
-
-    context "when sort params are nested attributes" do
-      let(:joined_collection) { instance_double "joined_collection", reorder: reordered_collection }
-      let(:collection_class) { Class.new }
-      let(:user_arel_table) { instance_double "arel_table" }
-
-      let(:sort_params) { {sort: "user.last_name,-user.first_name"} }
-
-      before do
-        stub_const "User", collection_class
-
-        allow(collection).to receive(:left_joins).and_return(joined_collection)
-        allow(collection).to receive(:model_name).and_return(instance_double("model_name", name: "User"))
-        allow(collection_class).to receive(:arel_table).and_return(user_arel_table)
-        allow(user_arel_table).to receive("[]").with("first_name").and_return(
-          instance_double("user_last_name_arel_column", asc: "first_name_asc", desc: "first_name_desc")
-        )
-        allow(user_arel_table).to receive("[]").with("last_name").and_return(
-          instance_double("user_last_name_arel_column", asc: "last_name_asc", desc: "last_name_desc")
-        )
-
-        TestQuery.sorts_by user: %i[first_name last_name]
-      end
-
-      it "left joins the nested table" do
-        sort
-
-        expect(collection).to have_received(:left_joins).with(:user)
-      end
-
-      it "splits the params to a hash" do
-        sort
-
-        expect(joined_collection).to have_received(:reorder).with(%w[last_name_asc first_name_desc])
+        expect(collection).to have_received(:order).with(id: :asc)
       end
     end
 
     context "when one or more of sort params is not permitted" do
-      let(:sort_params) { {sort: "first_name,email,birth_date,user.email,-user.first_name"} }
+      let(:params) { {sort: "first_name,email,-birth_date"} }
 
       context "when query does not support nested parameters" do
         it "raises an unpermitted sort parameters error" do
           expect { sort }.to raise_error(
             Jsonapi::QueryBuilder::Mixins::Sort::UnpermittedSortParameters,
-            "email, birth_date, user.email, and user.first_name are not permitted sort attributes"
-          )
-        end
-      end
-
-      context "when query supports nested parameters" do
-        before do
-          TestQuery.sorts_by user: %i[first_name]
-        end
-
-        it "raises an unpermitted sort parameters error" do
-          expect { sort }.to raise_error(
-            Jsonapi::QueryBuilder::Mixins::Sort::UnpermittedSortParameters,
-            "email, birth_date, and user.email are not permitted sort attributes"
+            "email and birth_date are not permitted sort attributes"
           )
         end
       end
     end
 
     context "when sort params are passed explicitly to #sort" do
-      subject(:sort) { TestQuery.new(collection, params).sort(collection, sort_params) }
+      subject(:sort) { SortableQuery.new(collection, params).sort(collection, sort_params) }
 
       let(:params) { {sort: "email"} }
       let(:sort_params) { "first_name,-last_name" }
 
-      it "overrides with the passed sort string" do
+      it "overrides with the passed sort string", :aggregate_failures do
         sort
 
-        expect(collection).to have_received(:reorder).with(%w[first_name_asc last_name_desc])
+        expect(collection).not_to have_received(:order).with(email: :asc)
+        expect(collection).to have_received(:order).with(name: :asc)
+        expect(collection).to have_received(:order).with(last_name: :desc)
       end
     end
   end

--- a/spec/jsonapi/query_builder_spec.rb
+++ b/spec/jsonapi/query_builder_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Jsonapi::QueryBuilder do
     let(:query_class) {
       Class.new(Jsonapi::QueryBuilder::BaseQuery) {
         default_sort :last_name
-        sorts_by :first_name, :last_name
+        sorts_by :first_name
+        sorts_by :last_name
 
         filters_by :first_name
         filters_by :email, ->(collection, query) { collection.where("email ilike ?", "%#{query}%") }
@@ -51,7 +52,6 @@ RSpec.describe Jsonapi::QueryBuilder do
       stub_const "TypeFilter", type_filter_class
       stub_const "Query", query_class
 
-      allow(collection).to receive(:reorder).and_return(collection)
       allow(collection).to receive(:order).and_return(collection)
       allow(collection).to receive(:includes).and_return(collection)
       allow(collection).to receive(:where).and_return(collection)
@@ -73,10 +73,11 @@ RSpec.describe Jsonapi::QueryBuilder do
         expect(collection).to have_received(:includes).with([{books: :tags}])
       end
 
-      it "reorders the collection" do
+      it "orders the collection", :aggregate_failures do
         results
 
-        expect(collection).to have_received(:reorder).with([Arel.sql("first_name").asc, Arel.sql("last_name").desc])
+        expect(collection).to have_received(:order).with(first_name: :asc)
+        expect(collection).to have_received(:order).with(last_name: :desc)
       end
 
       it "adds unique sort attribute" do

--- a/spec/jsonapi/query_builder_spec.rb
+++ b/spec/jsonapi/query_builder_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Jsonapi::QueryBuilder do
         end
       }
     }
+
     let(:collection) { instance_double "collection" }
 
     let(:params) {
@@ -66,22 +67,22 @@ RSpec.describe Jsonapi::QueryBuilder do
 
       it { is_expected.to eql collection }
 
+      it "includes included relationships" do
+        results
+
+        expect(collection).to have_received(:includes).with([{books: :tags}])
+      end
+
       it "reorders the collection" do
         results
 
-        expect(collection).to have_received(:reorder).with(first_name: :asc, last_name: :desc)
+        expect(collection).to have_received(:reorder).with([Arel.sql("first_name").asc, Arel.sql("last_name").desc])
       end
 
       it "adds unique sort attribute" do
         results
 
         expect(collection).to have_received(:order).with(id: :asc)
-      end
-
-      it "includes included relationships" do
-        results
-
-        expect(collection).to have_received(:includes).with([{books: :tags}])
       end
 
       it "filters the collection by passed filter params", :aggregate_failures do


### PR DESCRIPTION
### Aim
Allow sorting by `has_one`/`belongs_to` relationships attributes.

### Solution
~Extend the sort concern to include the needed relationships and use arel sql to build the correct sort parameter.~
Added support for passing sort lambdas or sort objects where the users can implement advanced sort implementations, like joining an supporting sorting on nested attributes or by computed attributes.