### PR TITLE
Bump Ruby version to allow Ruby 3

### DIFF
--- a/jsonapi-query_builder.gemspec
+++ b/jsonapi-query_builder.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = "~> 2.5"
+  spec.required_ruby_version = ['>= 2.5', '<= 3.0']
 
   spec.add_runtime_dependency "activerecord", ">= 5"
   spec.add_runtime_dependency "pagy", "~> 3.5"


### PR DESCRIPTION
This PR set `spec.required_ruby_version = ['>= 2.5', '<= 3.0']` in gemspec to allow gem usage with Ruby 3.

All specs are passed with Ruby 3.
![Screenshot from 2021-01-25 15-34-20](https://user-images.githubusercontent.com/77623406/105706653-dc087280-5f22-11eb-8c98-25cc778e0dcb.png)
