### PR TITLE
Remove Ruby `to` version.

### DIFF
--- a/jsonapi-query_builder.gemspec
+++ b/jsonapi-query_builder.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = [">= 2.5", "<= 3.0"]
+  spec.required_ruby_version = ">= 2.5"
 
   spec.add_runtime_dependency "activerecord", ">= 5"
   spec.add_runtime_dependency "pagy", "~> 3.5"


### PR DESCRIPTION
Since Ruby 3.0.1 released it's impossible to install `jsonapi-query_builder` with it. I suggest not to fix `to` Ruby version and allow to install gem with any future Ruby version. So gem will only have minimal Ruby requirement. 

All specs are passed with Ruby 3.0.1
![Screenshot from 2021-05-07 09-12-44](https://user-images.githubusercontent.com/77623406/117405605-917c9600-af14-11eb-9ba7-1583b7927dac.png)
