### PR TITLE
Encapsulate pagination logic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,12 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    actionview (6.1.1)
+      activesupport (= 6.1.1)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.1, >= 1.2.0)
     activemodel (6.1.3.1)
       activesupport (= 6.1.3.1)
     activerecord (6.1.3.1)
@@ -20,16 +26,49 @@ GEM
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
     ast (2.4.1)
+    builder (3.2.4)
+    coderay (1.1.3)
     concurrent-ruby (1.1.8)
+    crass (1.0.6)
     diff-lcs (1.4.4)
+    erubi (1.10.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    kaminari (1.2.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
+      actionview
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
+      activerecord
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     lefthook (0.7.2)
+    loofah (2.12.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    method_source (1.0.0)
+    mini_portile2 (2.6.1)
     minitest (5.14.4)
+    nokogiri (1.12.5)
+      mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
     pagy (3.11.0)
     parallel (1.20.1)
     parser (3.0.0.0)
       ast (~> 2.4.1)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    racc (1.5.2)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.4.2)
+      loofah (~> 2.3)
     rainbow (3.0.0)
     rake (13.0.3)
     regexp_parser (2.0.3)
@@ -65,6 +104,7 @@ GEM
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
+    sqlite3 (1.4.2)
     standard (0.11.0)
       rubocop (= 1.7.0)
       rubocop-performance (= 1.9.2)
@@ -79,12 +119,16 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord
   bundler (~> 2.0)
   jsonapi-query_builder!
+  kaminari (~> 1.2)
   lefthook
+  pry
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop-rspec
+  sqlite3
   standard
   standardrb
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Or install it yourself as:
 
 ```ruby
 class UserQuery < Jsonapi::QueryBuilder::BaseQuery
+  ## pagination 
+  paginator Jsonapi::QueryBuilder::Paginator::Pagy # default paginator
+  
   ## sorting
   default_sort created_at: :desc
   sorts_by :last_name
@@ -55,6 +58,29 @@ we can pass them as an unsafe hash. `Jsonapi::QueryBuilder::BaseQuery` should no
 current user permissions, or for any other type of scoping. It's only responsibility is to support the `json:api`
 querying. Use `pundit` or similar for policy scoping, custom query objects for other scoping, and then pass the scoped
 collection to the `Jsonapi::QueryBuilder::BaseQuery` object.
+
+### Pagination
+Pagination support is configurable using the `paginator` method to define the paginator. It defaults to the `Pagy`
+paginator, a lightweight and fast paginator. Other paginators currently supported are `Kaminari` and an implementation
+of keyset pagination. Before using these paginators we need to explicitly require the gems in our Gemfile and the
+paginator file in question. 
+Additionally one can implement it's own paginator by inheriting from `Jsonapi::QueryBuilder::Paginator::BasePaginator`.
+The minimum required implementation is a `#paginate` method that receives page params and returns a page of the
+collection. It can return the pagination details as the second item of the returned array, that can be used in the
+serializer for pagination metadata.
+#### Using the Kaminari Paginator
+```ruby
+require "jsonapi/query_builder/paginator/kaminari"
+
+paginator Jsonapi::QueryBuilder::Paginator::Kaminari
+```
+
+#### Using the Keyset Paginator
+```ruby
+require "jsonapi/query_builder/paginator/keyset"
+
+paginator Jsonapi::QueryBuilder::Paginator::Keyset
+```
 
 ### Sorting
 #### Ensuring deterministic results

--- a/jsonapi-query_builder.gemspec
+++ b/jsonapi-query_builder.gemspec
@@ -48,4 +48,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "standard"
   spec.add_development_dependency "rubocop-rspec"
   spec.add_development_dependency "lefthook"
+  spec.add_development_dependency "kaminari", "~> 1.2"
+  spec.add_development_dependency "activerecord"
+  spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "pry"
 end

--- a/lib/jsonapi/query_builder.rb
+++ b/lib/jsonapi/query_builder.rb
@@ -4,8 +4,6 @@ require "active_support/concern"
 require "active_support/core_ext/array/conversions"
 require "active_support/core_ext/hash/keys"
 require "active_support/core_ext/string/inflections"
-require "pagy"
-require "pagy/extras/items"
 
 require "jsonapi/query_builder/version"
 require "jsonapi/query_builder/base_query"

--- a/lib/jsonapi/query_builder/base_query.rb
+++ b/lib/jsonapi/query_builder/base_query.rb
@@ -5,6 +5,8 @@ require "jsonapi/query_builder/mixins/include"
 require "jsonapi/query_builder/mixins/paginate"
 require "jsonapi/query_builder/mixins/sort"
 
+require "jsonapi/query_builder/paginator"
+
 module Jsonapi
   module QueryBuilder
     class BaseQuery

--- a/lib/jsonapi/query_builder/errors/unpermitted_sort_parameters.rb
+++ b/lib/jsonapi/query_builder/errors/unpermitted_sort_parameters.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Jsonapi
+  module QueryBuilder
+    module Errors
+      class UnpermittedSortParameters < ArgumentError
+        def initialize(unpermitted_parameters)
+          super [
+            unpermitted_parameters.to_sentence,
+            unpermitted_parameters.count == 1 ? "is not a" : "are not",
+            "permitted sort attribute".pluralize(unpermitted_parameters.count)
+          ].join(" ")
+        end
+      end
+    end
+  end
+end

--- a/lib/jsonapi/query_builder/paginator.rb
+++ b/lib/jsonapi/query_builder/paginator.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require "jsonapi/query_builder/paginator/base_paginator"
+require "jsonapi/query_builder/paginator/pagy"

--- a/lib/jsonapi/query_builder/paginator/base_paginator.rb
+++ b/lib/jsonapi/query_builder/paginator/base_paginator.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Jsonapi
+  module QueryBuilder
+    module Paginator
+      class BasePaginator
+        attr_reader :collection
+
+        # @param [ActiveRecord::Relation] collection
+        def initialize(collection)
+          @collection = collection
+        end
+
+        # @param [Hash] page_params
+        # @return [[ActiveRecord::Relation, Hash]] Records and pagination details
+        def paginate(page_params)
+          raise NotImplementedError, "#{self.class} should implement ##{__method__}"
+        end
+      end
+    end
+  end
+end

--- a/lib/jsonapi/query_builder/paginator/kaminari.rb
+++ b/lib/jsonapi/query_builder/paginator/kaminari.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "kaminari"
+
+module Jsonapi
+  module QueryBuilder
+    module Paginator
+      class Kaminari < BasePaginator
+        def paginate(page_params)
+          paged_collection = collection
+            .page(page_params[:number])
+            .per(page_params[:size])
+            .padding(page_params[:offset])
+
+          [paged_collection, pagination_details(paged_collection, page_params)]
+        end
+
+        private
+
+        def pagination_details(collection, page_params)
+          {
+            number: collection.current_page,
+            size: collection.limit_value,
+            offset: page_params[:offset],
+            total: collection.total_count,
+            total_pages: collection.total_pages,
+            next_page: collection.next_page,
+            prev_page: collection.prev_page
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/jsonapi/query_builder/paginator/keyset.rb
+++ b/lib/jsonapi/query_builder/paginator/keyset.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "active_record"
+
+module Jsonapi
+  module QueryBuilder
+    module Paginator
+      class Keyset < BasePaginator
+        DEFAULT_DIRECTION = :after
+        DEFAULT_LIMIT = 25
+
+        def paginate(page_params)
+          page_params = extract_pagination_params(page_params)
+          records = apply_pagination(collection, page_params)
+
+          [records, page_params]
+        end
+
+        private
+
+        def extract_pagination_params(params)
+          {
+            column: params.fetch(:column, nil),
+            position: params.fetch(:position, nil),
+            direction: params.fetch(:direction, DEFAULT_DIRECTION),
+            limit: params.fetch(:limit, DEFAULT_LIMIT)
+          }
+        end
+
+        def apply_pagination(collection, pagination_params)
+          column = pagination_params[:column]
+          position = pagination_params[:position]
+          direction = pagination_params[:direction]
+          limit = pagination_params[:limit]
+
+          return collection unless column
+
+          collection = apply_order(collection, column, direction)
+          collection = collection.limit(limit.to_i)
+
+          return collection unless position
+
+          apply_filter(collection, column, position, direction)
+        end
+
+        def apply_order(collection, column, direction)
+          if direction.to_sym == DEFAULT_DIRECTION
+            collection.reorder(collection.arel_table[column].asc)
+          else
+            collection.reorder(collection.arel_table[column].desc)
+          end
+        end
+
+        def apply_filter(collection, column, position, direction)
+          if direction.to_sym == DEFAULT_DIRECTION
+            collection.where(collection.arel_table[column].gt(position))
+          else
+            collection.where(collection.arel_table[column].lt(position))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/jsonapi/query_builder/paginator/pagy.rb
+++ b/lib/jsonapi/query_builder/paginator/pagy.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "pagy"
+require "pagy/extras/items"
+
+module Jsonapi
+  module QueryBuilder
+    module Paginator
+      class Pagy < BasePaginator
+        include ::Pagy::Backend
+
+        def paginate(page_params)
+          @params = {page: page_params}
+
+          pagination_details, records = pagy collection, page: page_params[:number],
+                                                         items: page_params[:size],
+                                                         outset: page_params[:offset]
+          [records, pagination_details]
+        end
+
+        private
+
+        attr_reader :params
+      end
+    end
+  end
+end

--- a/spec/jsonapi/query_builder/errors/unpermitted_sort_parameters_spec.rb
+++ b/spec/jsonapi/query_builder/errors/unpermitted_sort_parameters_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe Jsonapi::QueryBuilder::Errors::UnpermittedSortParameters do
+  context "when there is a single unpermitted sort parameter" do
+    let(:unpermitted_parameters) { %w[first_name] }
+
+    it "raises an exception with a single unpermitted parameter error message" do
+      expect {
+        raise described_class, unpermitted_parameters
+      }.to raise_error(described_class, "first_name is not a permitted sort attribute")
+    end
+  end
+
+  context "when there are multiple unpermitted sort parameters" do
+    let(:unpermitted_parameters) { %w[first_name last_name email] }
+
+    it "raises an exception with multiple unpermitted parameters error message" do
+      expect {
+        raise described_class, unpermitted_parameters
+      }.to raise_error(described_class, "first_name, last_name, and email are not permitted sort attributes")
+    end
+  end
+end

--- a/spec/jsonapi/query_builder/mixins/filter_spec.rb
+++ b/spec/jsonapi/query_builder/mixins/filter_spec.rb
@@ -3,9 +3,9 @@
 RSpec.describe Jsonapi::QueryBuilder::Mixins::Filter do
   describe "DSL" do
     subject(:filterable_query_class) do
-      Class.new {
+      Class.new do
         include Jsonapi::QueryBuilder::Mixins::Filter
-      }
+      end
     end
 
     before do

--- a/spec/jsonapi/query_builder/mixins/paginate_spec.rb
+++ b/spec/jsonapi/query_builder/mixins/paginate_spec.rb
@@ -1,33 +1,59 @@
 # frozen_string_literal: true
 
 RSpec.describe Jsonapi::QueryBuilder::Mixins::Paginate do
-  let(:paged_query_class) do
-    Class.new {
-      include Jsonapi::QueryBuilder::Mixins::Paginate
+  describe "DSL" do
+    subject(:paginatable_query_class) do
+      require "jsonapi/query_builder/paginator/kaminari"
 
-      attr_reader :params
-
-      def initialize(params)
-        @params = params
+      Class.new do
+        include Jsonapi::QueryBuilder::Mixins::Paginate
       end
-    }
-  end
-  let(:paged_query) { PagedQuery.new params }
+    end
 
-  before do
-    stub_const "PagedQuery", paged_query_class
+    before do
+      stub_const "PaginatableQuery", paginatable_query_class
+    end
+
+    describe ".paginator" do
+      it "registers a new paginator" do
+        PaginatableQuery.paginator Jsonapi::QueryBuilder::Paginator::Kaminari
+
+        expect(PaginatableQuery._paginator).to eql Jsonapi::QueryBuilder::Paginator::Kaminari
+      end
+    end
+
+    describe "._paginator" do
+      it "defaults to Pagy paginator" do
+        expect(PaginatableQuery._paginator).to eql Jsonapi::QueryBuilder::Paginator::Pagy
+      end
+    end
   end
 
   describe "#paginate" do
     subject(:paginate) { paged_query.paginate(collection) }
 
+    let(:paged_query_class) do
+      Class.new do
+        include Jsonapi::QueryBuilder::Mixins::Paginate
+
+        attr_reader :params
+
+        def initialize(params)
+          @params = params
+        end
+      end
+    end
     let(:collection) { instance_double "collection" }
-    let(:pagination_details) { instance_double "pagination-details" }
+    let(:paged_query) { PagedQuery.new page: {number: 2, size: 20, offset: 0} }
     let(:paged_collection) { instance_double "paged-collection" }
-    let(:params) { {page: {number: 2, size: 20, offset: 0}} }
+    let(:pagination_details) { instance_double "pagination-details" }
+    let(:paginator) do
+      instance_double Jsonapi::QueryBuilder::Paginator::Pagy, paginate: [paged_collection, pagination_details]
+    end
 
     before do
-      allow(paged_query).to receive(:pagy).and_return([pagination_details, paged_collection])
+      stub_const "PagedQuery", paged_query_class
+      allow(Jsonapi::QueryBuilder::Paginator::Pagy).to receive(:new).and_return(paginator)
     end
 
     it "returns the paged collection" do
@@ -40,18 +66,19 @@ RSpec.describe Jsonapi::QueryBuilder::Mixins::Paginate do
       expect(paged_query.pagination_details).to eql(pagination_details)
     end
 
-    it "passes the params to pagy" do
+    it "passes the collection and params to default Pagy paginator" do # rubocop:disable RSpec/MultipleExpectations
       paginate
 
-      expect(paged_query).to have_received(:pagy).with(anything, page: 2, items: 20, outset: 0)
+      expect(Jsonapi::QueryBuilder::Paginator::Pagy).to have_received(:new).with(collection)
+      expect(paginator).to have_received(:paginate).with(number: 2, size: 20, offset: 0)
     end
 
     it "defaults to page number 1" do
-      params[:page].delete(:number)
+      paged_query.params[:page].delete(:number)
 
       paginate
 
-      expect(paged_query).to have_received(:pagy).with(anything, hash_including(page: 1))
+      expect(paginator).to have_received(:paginate).with(hash_including(number: 1))
     end
 
     context "when paginate params are passed explicitly to #paginate" do
@@ -62,7 +89,7 @@ RSpec.describe Jsonapi::QueryBuilder::Mixins::Paginate do
       it "overrides with the passed page params" do
         paginate
 
-        expect(paged_query).to have_received(:pagy).with(anything, hash_including(page: 3, items: 30))
+        expect(paginator).to have_received(:paginate).with(number: 3, size: 30)
       end
     end
   end

--- a/spec/jsonapi/query_builder/mixins/sort_spec.rb
+++ b/spec/jsonapi/query_builder/mixins/sort_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Jsonapi::QueryBuilder::Mixins::Sort do
       context "when query does not support nested parameters" do
         it "raises an unpermitted sort parameters error" do
           expect { sort }.to raise_error(
-            Jsonapi::QueryBuilder::Mixins::Sort::UnpermittedSortParameters,
+            Jsonapi::QueryBuilder::Errors::UnpermittedSortParameters,
             "email and birth_date are not permitted sort attributes"
           )
         end

--- a/spec/jsonapi/query_builder/paginator/base_paginator_spec.rb
+++ b/spec/jsonapi/query_builder/paginator/base_paginator_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe Jsonapi::QueryBuilder::Paginator::BasePaginator do
+  before do
+    stub_const "FakePaginator", paginator_class
+  end
+
+  context "with required interface methods" do
+    let(:paginator_class) { Class.new described_class }
+
+    it "raises an error for paginate method" do
+      expect {
+        FakePaginator.new(instance_double("collection")).paginate(instance_double("page_params"))
+      }.to raise_error(NotImplementedError, "FakePaginator should implement #paginate")
+    end
+  end
+end

--- a/spec/jsonapi/query_builder/paginator/kaminari_spec.rb
+++ b/spec/jsonapi/query_builder/paginator/kaminari_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "jsonapi/query_builder/paginator/kaminari"
+
+RSpec.describe Jsonapi::QueryBuilder::Paginator::Kaminari do
+  describe "#paginate" do
+    subject(:paginate) { described_class.new(collection).paginate(number: 2, size: 20, offset: 3) }
+
+    let(:collection) { instance_double "collection" }
+    let(:paged_collection) do
+      instance_double "paged-collection", current_page: 2,
+                                          limit_value: 20,
+                                          total_count: 35,
+                                          total_pages: 2,
+                                          next_page: nil,
+                                          prev_page: 1
+    end
+
+    before do
+      allow(collection).to receive(:page).and_return(collection)
+      allow(collection).to receive(:per).and_return(collection)
+      allow(collection).to receive(:padding).and_return(paged_collection)
+    end
+
+    it { is_expected.to be_an Array }
+
+    it "returns the paged collection as first item of the returned array" do
+      expect(paginate[0]).to eql paged_collection
+    end
+
+    it "returns the pagination details as the second item of the returned array" do
+      expected_pagination_details = {number: 2, size: 20, offset: 3,
+                                     total: 35, total_pages: 2,
+                                     next_page: nil, prev_page: 1}
+
+      expect(paginate[1]).to eql expected_pagination_details
+    end
+
+    it "calls the kaminari pagination methods on the passed collection", :aggregate_failures do
+      paginate
+
+      expect(collection).to have_received(:page).with(2)
+      expect(collection).to have_received(:per).with(20)
+      expect(collection).to have_received(:padding).with(3)
+    end
+  end
+end

--- a/spec/jsonapi/query_builder/paginator/keyset_spec.rb
+++ b/spec/jsonapi/query_builder/paginator/keyset_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "support/active_record"
+require "jsonapi/query_builder/paginator/keyset"
+
+# rubocop:disable RSpec/ExampleLength
+RSpec.describe Jsonapi::QueryBuilder::Paginator::Keyset do
+  subject(:keyset_paginator) { described_class.new(Post.all) }
+
+  it "returns original collection when column isn't provided" do
+    paginated_collection, _details = keyset_paginator.paginate({})
+
+    expect(paginated_collection.to_sql).to eq <<~SQL.squish
+      SELECT "posts".*
+      FROM "posts"
+    SQL
+  end
+
+  it "orders collection by the selected column" do
+    params = {column: :id}
+    paginated_collection, _details = keyset_paginator.paginate(params)
+
+    expect(paginated_collection.to_sql).to eq <<~SQL.squish
+      SELECT "posts".*
+      FROM "posts"
+      ORDER BY "posts"."id" ASC
+      LIMIT 25
+    SQL
+  end
+
+  it "applies selected limit" do
+    params = {column: :id, limit: 10}
+    paginated_collection, _details = keyset_paginator.paginate(params)
+
+    expect(paginated_collection.to_sql).to eq <<~SQL.squish
+      SELECT "posts".*
+      FROM "posts"
+      ORDER BY "posts"."id" ASC
+      LIMIT 10
+    SQL
+  end
+
+  context "when direction isn't provided" do
+    it "filters records after the selected position" do
+      params = {column: :id, limit: 10, position: 5}
+      paginated_collection, _details = keyset_paginator.paginate(params)
+
+      expect(paginated_collection.to_sql).to eq <<~SQL.squish
+        SELECT "posts".*
+        FROM "posts"
+        WHERE "posts"."id" > 5
+        ORDER BY "posts"."id" ASC
+        LIMIT 10
+      SQL
+    end
+  end
+
+  context "when selecting records after the position" do
+    it "filters records after the selected position" do
+      params = {column: :id, limit: 10, position: 5, direction: :after}
+      paginated_collection, _details = keyset_paginator.paginate(params)
+
+      expect(paginated_collection.to_sql).to eq <<~SQL.squish
+        SELECT "posts".*
+        FROM "posts"
+        WHERE "posts"."id" > 5
+        ORDER BY "posts"."id" ASC
+        LIMIT 10
+      SQL
+    end
+  end
+
+  context "when selecting records before the position" do
+    it "filters records before the selected position" do
+      params = {column: :id, limit: 10, position: 5, direction: :before}
+      paginated_collection, _details = keyset_paginator.paginate(params)
+
+      expect(paginated_collection.to_sql).to eq <<~SQL.squish
+        SELECT "posts".*
+        FROM "posts"
+        WHERE "posts"."id" < 5
+        ORDER BY "posts"."id" DESC
+        LIMIT 10
+      SQL
+    end
+  end
+end
+# rubocop:enable RSpec/ExampleLength

--- a/spec/jsonapi/query_builder/paginator/pagy_spec.rb
+++ b/spec/jsonapi/query_builder/paginator/pagy_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe Jsonapi::QueryBuilder::Paginator::Pagy do
+  describe "#paginate" do
+    subject(:paginate) { pagy_paginator.paginate(number: 2, size: 20, offset: 3) }
+
+    let(:pagy_paginator) { described_class.new(collection) }
+    let(:collection) { instance_double "collection" }
+    let(:paged_collection) { instance_double "paged-collection" }
+    let(:pagination_details) { instance_double Pagy, "pagination-details" }
+
+    before do
+      allow(pagy_paginator).to receive(:pagy).and_return([pagination_details, paged_collection])
+    end
+
+    it { is_expected.to be_an Array }
+
+    it "returns the records and pagination details" do
+      expect(paginate).to eql [paged_collection, pagination_details]
+    end
+
+    it "passes the collection and pagination params to pagy method" do
+      paginate
+
+      expect(pagy_paginator).to have_received(:pagy).with(collection, page: 2, items: 20, outset: 3)
+    end
+
+    it "sets the private params attribute reader used internally by pagy backend" do
+      paginate
+
+      expect(pagy_paginator.send(:params)).to eql page: {number: 2, size: 20, offset: 3}
+    end
+  end
+end

--- a/spec/jsonapi/query_builder_spec.rb
+++ b/spec/jsonapi/query_builder_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_record"
-
 RSpec.describe Jsonapi::QueryBuilder do
   it "has a version number" do
     expect(Jsonapi::QueryBuilder::VERSION).not_to be nil
@@ -12,6 +10,8 @@ RSpec.describe Jsonapi::QueryBuilder do
 
     let(:query_class) {
       Class.new(Jsonapi::QueryBuilder::BaseQuery) {
+        paginator Jsonapi::QueryBuilder::Paginator::Pagy
+
         default_sort :last_name
         sorts_by :first_name
         sorts_by :last_name

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "active_record"
+
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+ActiveRecord::Schema.define do
+  create_table :posts, force: true do |t|
+    t.string :title
+  end
+end
+
+class Post < ActiveRecord::Base
+end


### PR DESCRIPTION
### AIM
Extract pagination logic into paginators. Support Kaminari pagination and keyset pagination. Optionally the paginators can be overridden to return different pagination details, in case if the serializer metadata warrants any other details.